### PR TITLE
Documentation, test structure, missing values...

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: glmExtras
 Title: GLM extras
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: 
     person("Andreas", "Jangmo", , "andreas.jangmo@fhi.no", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-6928-4791"))

--- a/R/helper.R
+++ b/R/helper.R
@@ -31,6 +31,6 @@ dtaSamp$z <- rnorm(nrow(dtaSamp))
 # (1 - exp((D.full - D.base)/n))/(1 - exp(-D.base/n))
 # (1 - exp((rr$dev - rr$null)/n))/(1 - exp(-rr$null/n)) #fmsb
 
-library(DescTools, quietly=T)
+#library(DescTools, quietly=T) # Install fail
 library(fmsb, quietly=T)
 library(r2redux, quietly=T)

--- a/R/helper.R
+++ b/R/helper.R
@@ -1,0 +1,36 @@
+# the generated G explains 50% of liabilty
+n <- 10000
+# This results in Y~N(0,1)
+vr <- 1/sqrt(2)
+x <- rnorm(n, sd=vr)
+er <- rnorm(n, sd=vr)
+
+prevalence <- 0.1
+prevalenceSample <- 0.5
+# We set the threshold corresponding to the prevalence above
+th <- -qnorm(prevalence)
+# Create the outcome with an error
+dta <- data.frame(y = x + er, x=x)
+# Create cases
+dta$yth <- as.integer(dta$y > th)
+
+# Calculate number of cases in the population that should roughly be prevalence*n
+nCas <- nrow(subset(dta, yth==1))
+# N in sample will thus be
+nSample <- nCas/prevalenceSample
+# N controls
+nCont <- abs(nSample - nCas)
+
+# Now we draw a random sample so that we get the sample prevalence defined above
+set.seed(123)
+dtaSamp <- rbind(subset(dta, yth==1),
+                 subset(dta, yth==0)[sample(1:(n-nCas), nCas),])
+# Add an error term
+dtaSamp$z <- rnorm(nrow(dtaSamp))
+# Desctools Nagelkerke: This package does not comply with fmsb
+# (1 - exp((D.full - D.base)/n))/(1 - exp(-D.base/n))
+# (1 - exp((rr$dev - rr$null)/n))/(1 - exp(-rr$null/n)) #fmsb
+
+library(DescTools, quietly=T)
+library(fmsb, quietly=T)
+library(r2redux, quietly=T)

--- a/R/r2wrap.R
+++ b/R/r2wrap.R
@@ -11,7 +11,7 @@
 #'
 #' @export
 #' @param mod The fitted model object
-#' @param comparison A formula to compare the model `mod` with, e.g. ~-exposure to remove `exposure` from `mod`
+#' @param comparison A formula to compare the model `mod` with, e.g. `. ~ . -exposure` to remove `exposure` from `mod`
 #' @param cases N of `y=1`
 #' @param controls N of `y=0`
 R2Wrap <- function (mod, comparison=~0, cases=NA_integer_, controls=NA_integer_) {
@@ -174,7 +174,7 @@ setMethod('R2.scaleLiability', signature=c('glm-binomial', 'numeric', 'missing',
               o@comparison <- ~0
               r22 <- R2.scaleLiability(o, prevalence)
               r2 <- r2 - r22
-              cat ('Main model:', deparse(object@model$formula), '\nComparison:', deparse(o@model$formula), '\n')
+              message('Main model: ', deparse(object@model$formula), '\nComparison: ', deparse(o@model$formula), '\n')
             }
             r2
           })
@@ -185,12 +185,14 @@ setGeneric('R2.scaleObserved', function (object) standardGeneric('R2.scaleObserv
 setMethod('R2.scaleObserved', signature='glm-binomial',
           function (object) {
             preds <- predict(object@model, type='response')
+            if (sum(is.na(preds)) > 0) stop('Data contains missing values (NA)')
             r2 <- var(preds)/((object@cases/object@N) * (object@controls/object@N))
             r2
           })
 setMethod('R2.scaleObserved', signature=c('glm-gaussian'),
           function (object) {
             preds <- predict(object@model)
+            if (sum(is.na(preds)) > 0) stop('Data contains missing values (NA)')
             if (is.na(object@cases)) {
               den <- var(object@model$y)
             } else {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ devtools::install_github('https://github.com/deepchocolate/glm-extras')
 
 Otherwise, download one of the release .tar.gz-files and issue:
 ```
-install.packages('glm-extras-0.0.0.tar.gz', repos=NULL)
+install.packages('glm-extras-0.0.2.tar.gz', repos=NULL)
 
 ```
 
@@ -99,3 +99,9 @@ R2.scaleLiability(m1R, prevalence=0.1) - R2.scaleLiability(m2R, prevalence=0.1)
 ```
 # References
 Lee, S.H., Goddard, M.e., Wray, N.R. and Visscher, P.M. (2012), A Better Coefficient of Determination for Genetic Profile Analysis. Genet. Epidemiol., 36: 214-224. https://doi.org/10.1002/gepi.21614
+
+# Version history
+
+## 0.0.2
+- Added exception when data contains missing values
+- Minor changes to documentation and messages

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ mR2 <- R2Wrap(m, cases=#, controls#)
 
 ### Comparing models
 
-If the R2Wrap object is instantiated with a formula, this provides a convinient way
-of getting an incremental R2.
+If the R2Wrap object is instantiated with a formula, this provides a convenient way
+of getting an incremental R2. Note that this formula should adhere to `update.formula()`.
+If the model is `y ~ x + z` the comparison argument for calculating incremental R2 of `x`
+should be `~ . -x` or `. ~ . -x`.
 ```
-mR2 <- R2Wrap(m, comparison=~-exposure)
+mR2 <- R2Wrap(m, comparison=.~.-exposure)
 R2.scaleLiability(m, prevalence=0.1)
 ```
 This will compare the model `yth~x` against `yth~1`. This is equivalent to 

--- a/tests/testthat/test_r2wrap.R
+++ b/tests/testthat/test_r2wrap.R
@@ -1,38 +1,3 @@
-# the generated G explains 50% of liabilty
-n <- 10000
-# This results in Y~N(0,1)
-vr <- 1/sqrt(2)
-x <- rnorm(n, sd=vr)
-er <- rnorm(n, sd=vr)
-
-prevalence <- 0.1
-prevalenceSample <- 0.5
-# We set the threshold corresponding to the prevalence above
-th <- -qnorm(prevalence)
-# Create the outcome with an error
-dta <- data.frame(y = x + er, x=x)
-# Create cases
-dta$yth <- as.integer(dta$y > th)
-
-# Calculate number of cases in the population that should roughly be prevalence*n
-nCas <- nrow(subset(dta, yth==1))
-# N in sample will thus be
-nSample <- nCas/prevalenceSample
-nCont <- abs(nSample - nCas)
-
-# Now we draw a random sample so that we get the sample prevalence defined above
-set.seed(123)
-dtaSamp <- rbind(subset(dta, yth==1),
-                 subset(dta, yth==0)[sample(1:(n-nCas), nCas),])
-dtaSamp$z <- rnorm(nrow(dtaSamp))
-# Desctools Nagelkerke: This package does not comply with fmsb
-# (1 - exp((D.full - D.base)/n))/(1 - exp(-D.base/n))
-# (1 - exp((rr$dev - rr$null)/n))/(1 - exp(-rr$null/n)) #fmsb
-
-summary(lm(y~x, data=dta))
-library(DescTools, quietly=T)
-library(fmsb, quietly=T)
-library(r2redux, quietly=T)
 # Compare with DescTools::PseudoR2 and r2redux::cc_trf
 test_that('Testing linear model on a y=1/0', {
   m <- glm(yth~x, data=dtaSamp)
@@ -59,11 +24,15 @@ test_that('Testing linear model on a y=1/0', {
   m <- glm(y~x, data=dta)
   mP <- R2Wrap(m)
   r2 <- round(R2.scaleObserved(mP)*100)
-  expect_equal(r2, 50)
+  expect_equal(r2, 50, tolerance=1)
 
-  #likelihoodR2(mP)
-  #nagelkerkeR2(mP)
-  #CoxSnellR2(mP)
+  # Test error with missing values
+  dtaSampBad <- dtaSamp
+  dtaSampBad$x[1] <- NA
+  # Default with glm is to na.omit, ie rows with NAs will be ignored
+  m <- glm(yth~x, data=dtaSampBad, na.action=na.exclude)
+  mP <- R2Wrap(m)
+  expect_error(R2.scaleObserved(mP))
 })
 
 test_that('Testing binomial model on a y=1/0', {
@@ -77,7 +46,6 @@ test_that('Testing binomial model on a y=1/0', {
   # Nagelkerke
   r2 <- NagelkerkeR2(m)$R2
   expect_equal(R2.Nagelkerke(mP), r2)
-
   # Scale liability
   # We calculate the observed scale R2 manually as this is not done by r2redux::cc_trf to get liability scale R2
   r2 <- var(predict(m, type='response'))/(prevalenceSample*(1-prevalenceSample))
@@ -85,8 +53,16 @@ test_that('Testing binomial model on a y=1/0', {
   # This function takes a SD of R2 aswell, but this is not relevant for the calculation of libability scale point estimate R2
   r2 <- cc_trf(r2, 0.01, K=prevalence, P=prevalenceSample)$R2l
   expect_equal(R2.scaleLiability(mP, prevalence), r2)
-
+  # This is just testing using a different coefficient (the error term)
   m <- glm(yth~x + z, data=dtaSamp, family=binomial)
   mP <- R2Wrap(m, comparison=~.-z)
-  expect_equal(round(10*R2.scaleLiability(mP, prevalence)), -1)
+  expect_equal(round(10*R2.scaleLiability(mP, prevalence)), 0)
+
+  # Test what happens with missingness
+  dtaSampBad <- dtaSamp
+  dtaSampBad$x[1] <- NA
+  # Default with glm is to na.omit, ie rows with NAs will be ignored
+  m <- glm(yth~x, data=dtaSampBad, family=binomial, na.action = na.exclude)
+  mP <- R2Wrap(m)
+  expect_error(R2.scaleLiability(mP, prevalence))
 })


### PR DESCRIPTION
- Changed output of messages from `cat` to `message`
- Moved test data generation from test files to `R/helper.R`
- Added exception when data contains `NA`. Might be better to add some option to omit missing values, but meanwhile this should generate an exception.
- Clarified documentation on how to use the `comparison` argument of `R2Wrap`.

Version incremented to `0.0.2`

Closes #1 
Closes #2